### PR TITLE
Fix issue when reading in parquet - make 'values' and 'id' cols

### DIFF
--- a/src/venomx/tools/file_io.py
+++ b/src/venomx/tools/file_io.py
@@ -64,8 +64,12 @@ def load_embeddings_as_pandas(
     if format == EmbeddingFormat.PARQUET:
         read_table = pq.read_table(str(source))
         df = read_table.to_pandas()
+        if "values" not in df.columns:
+            df["values"] = list(df.values)
         df["values"] = df["values"].apply(lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
-        # df['values'] = df['values'].apply(lambda x: list(x) if isinstance(x, tuple) else x)
+
+        if "id" not in df.columns:
+            df["id"] = list(df.index)
         return df
     else:
         raise ValueError(f"Unsupported format: {format}")


### PR DESCRIPTION
Solves this issue when converting parquet files. Issue seems to be that the code assumes that a pd df loaded from parquet has columns "values" and "id", which mine at least did not

```
venomx convert --input-embeddings-format parquet line_embedding.parquet --output ./test.yaml 
```

```
Traceback (most recent call last):
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3802, in get_loc
    return self._engine.get_loc(casted_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "index.pyx", line 153, in pandas._libs.index.IndexEngine.get_loc
  File "index.pyx", line 161, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index_class_helper.pxi", line 70, in pandas._libs.index.Int64Engine._check_type
KeyError: 'values'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jtr4v/PythonProject/venomx/.venv/bin/venomx", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/src/venomx/tools/cli.py", line 74, in convert
    ix = load_index(input_file, format=EmbeddingFormat(input_embeddings_format), check=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/src/venomx/tools/file_io.py", line 106, in load_index
    ix.embeddings_frame = load_embeddings_as_pandas(ix, embeddings, ef, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/src/venomx/tools/file_io.py", line 67, in load_embeddings_as_pandas
    df["values"] = df["values"].apply(lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
                   ~~^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/pandas/core/frame.py", line 4090, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jtr4v/PythonProject/venomx/.venv/lib/python3.11/site-packages/pandas/core/indexes/base.py", line 3809, in get_loc
    raise KeyError(key) from err
KeyError: 'values'

Process finished with exit code 1
```